### PR TITLE
OCI starter 3.X

### DIFF
--- a/basis/bin/auto_env.sh
+++ b/basis/bin/auto_env.sh
@@ -7,6 +7,7 @@ if [[ -z "${PROJECT_DIR}" ]]; then
 fi
 # TARGET_DIR
 export TARGET_DIR=$PROJECT_DIR/target
+export STATE_FILE=$TARGET_DIR/terraform.tfstate
 if [ ! -d $TARGET_DIR ]; then
   mkdir $TARGET_DIR
 fi
@@ -224,7 +225,6 @@ fi
 
 
 #-- POST terraform ----------------------------------------------------------
-export STATE_FILE=$TARGET_DIR/terraform.tfstate
 if [ -f $STATE_FILE ]; then
   # OBJECT_STORAGE_URL
   export OBJECT_STORAGE_URL=https://objectstorage.${TF_VAR_region}.oraclecloud.com

--- a/basis/bin/build_all.sh
+++ b/basis/bin/build_all.sh
@@ -10,7 +10,7 @@ SECONDS=0
 title "OCI Starter - Build"
 
 # First build is auto-approved. Else you need to pass --auto-approve flag.
-if [ "$1" != "--auto-approve" ]; then
+if [ "$1" == "--auto-approve" ]; then
    export TERRAFORM_FLAG="--auto-approve"
 elif [ -f $STATE_FILE ]; then
    echo "$STATE_FILE detected."

--- a/basis/bin/build_all.sh
+++ b/basis/bin/build_all.sh
@@ -9,6 +9,15 @@ SECONDS=0
 . starter.sh env -no-auto
 title "OCI Starter - Build"
 
+# First build is auto-approved. Else you need to pass --auto-approve flag.
+if [ "$1" != "--auto-approve" ]; then
+   export TERRAFORM_FLAG="--auto-approve"
+elif [ -f $STATE_FILE ]; then
+   echo "$STATE_FILE detected."
+else
+   export TERRAFORM_FLAG="--auto-approve"
+fi
+
 # Custom code before build
 if [ -f $PROJECT_DIR/src/before_build.sh ]; then
   $PROJECT_DIR/src/before_build.sh
@@ -27,7 +36,7 @@ if [ "$TF_VAR_tls" != "" ]; then
 fi  
 
 title "Terraform Apply"
-$BIN_DIR/terraform_apply.sh --auto-approve -no-color
+$BIN_DIR/terraform_apply.sh -no-color $TERRAFORM_FLAG
 exit_on_error
 
 . starter.sh env

--- a/basis/bin/destroy_all.sh
+++ b/basis/bin/destroy_all.sh
@@ -73,11 +73,18 @@ cleanBucket() {
 }
 for BUCKET_NAME in `cat $STATE_FILE | jq -r '.resources[] | select(.type=="oci_objectstorage_bucket") | .instances[].attributes.name'`;
 do
-   cleanBucket $BUCKET_NAME
+  cleanBucket $BUCKET_NAME
 done;
 
 title "Terraform Destroy"
 $BIN_DIR/terraform_destroy.sh --auto-approve -no-color
 exit_on_error
+
+export TF_RESOURCE=`cat $STATE_FILE | jq ".resources | length"`
+if [ "$TF_RESOURCE" == "0" ]; then
+  echo "Empty state file - cleaning up .terraform"
+  rm -Rf $PROJECT_DIR/src/terraform/.terraform
+  rm -Rf $PROJECT_DIR/src/terraform/.terraform.lock.hcl
+fi
 
 echo "Destroy time: ${SECONDS} secs"

--- a/basis/bin/shared_bash_function.sh
+++ b/basis/bin/shared_bash_function.sh
@@ -615,3 +615,28 @@ function scp_via_bastion() {
   i=$(($i+1))
   done
 }
+
+# Function to replace ##VARIABLES## in a file
+file_replace_variables() {
+  local file="$1"
+  local temp_file=$(mktemp)
+
+  while IFS= read -r line; do
+    while [[ $line =~ (.*)##(.*)##(.*) ]]; do
+      local var_name="${BASH_REMATCH[2]}"
+      local var_value="${!var_name}"
+
+      if [[ -z "$var_value" ]]; then
+        echo "ERROR: Environment variable '${var_name}' is not defined."
+        error_exit
+      fi
+
+      line=${line/"##${var_name}##"/${var_value}}
+    done
+
+    echo "$line" >> "$temp_file"
+  done < "$file"
+
+  mv "$temp_file" "$file"
+}
+

--- a/basis/bin/starter.sh
+++ b/basis/bin/starter.sh
@@ -101,11 +101,11 @@ elif [ "$ARG1" == "ssh" ]; then
   fi    
 elif [ "$ARG1" == "terraform" ]; then
   if [ "$ARG2" == "plan" ]; then
-    $BIN_DIR/terraform_plan.sh ${@:2}
+    $BIN_DIR/terraform_plan.sh ${@:3}
   elif [ "$ARG2" == "apply" ]; then
-    $BIN_DIR/terraform_apply.sh ${@:2}
+    $BIN_DIR/terraform_apply.sh ${@:3}
   elif [ "$ARG2" == "destroy" ]; then
-    $BIN_DIR/terraform_destroy.sh ${@:2}
+    $BIN_DIR/terraform_destroy.sh ${@:3}
   else 
     echo "Unknown command: $ARG1 $ARG2"
   fi    

--- a/basis/bin/starter.sh
+++ b/basis/bin/starter.sh
@@ -73,19 +73,16 @@ elif [ "$ARG1" == "help" ]; then
   exit
 
 elif [ "$ARG1" == "build" ]; then
-  if [ "$ARG2" == "" ]; then
-    export LOG_NAME=$TARGET_DIR/logs/build.${DATE_POSTFIX}.log
-    # Show the log and save it to target/build.log and target/logs
-    ln -sf $LOG_NAME $TARGET_DIR/build.log
-    $BIN_DIR/build_all.sh ${@:2} 2>&1 | tee $LOG_NAME
-  elif [ "$ARG2" == "app" ]; then
+  if [ "$ARG2" == "app" ]; then
     $PROJECT_DIR/src/app/build_app.sh ${@:2}
   elif [ "$ARG2" == "ui" ]; then
     $PROJECT_DIR/src/ui/build_ui.sh ${@:2}
   else 
-    echo "Unknown command: $ARG1 $ARG2"
+    export LOG_NAME=$TARGET_DIR/logs/build.${DATE_POSTFIX}.log
+    # Show the log and save it to target/build.log and target/logs
+    ln -sf $LOG_NAME $TARGET_DIR/build.log
+    $BIN_DIR/build_all.sh ${@:2} 2>&1 | tee $LOG_NAME
   fi    
-
 
 elif [ "$ARG1" == "destroy" ]; then
   LOG_NAME=$TARGET_DIR/logs/destroy.${DATE_POSTFIX}.log

--- a/basis/bin/upgrade.sh
+++ b/basis/bin/upgrade.sh
@@ -4,9 +4,48 @@ if [ "$PROJECT_DIR" == "" ]; then
   exit 1
 fi  
 cd $PROJECT_DIR
+
+
+# Call the script with --auto-approve to upgrade without prompt
+. starter.sh env -no-auto
+title "OCI Starter - Upgrade"
+echo 
+echo 
+
+export UPGRADE_DIR=$PROJECT_DIR/upgrade
+if [ -d upgrade ]; then
+  echo "ERROR: $UPGRADE_DIR exists already"
+  exit
+di
+
+if [ "$1" != "--auto-approve" ]; then
+  echo "Warning: Use at your own risk."
+  echo "It tries to upgrade the OCI-Starter version used to the latest one."
+  read -p "Do you want to proceed? (yes/no) " yn
+
+  case $yn in 
+  	yes ) echo Upgrading;;
+	no ) echo Exiting...;
+		exit;;
+	* ) echo Invalid response;
+		exit 1;;
+  esac
+fi
 . starter.sh env
 
-## Remove variable that should not be exposed
+if [ -d $TARGET_DIR ]; then
+  read -p "Warning: Target dir detected. Are you sure that you want to continue (yes/no) " yn
+  case $yn in 
+  	yes ) echo Upgrading;;
+	no ) echo Exiting...;
+		exit;;
+	* ) echo Invalid response;
+		exit 1;;
+  esac
+fi
+
+title "Remove variable that should not be exposed"
+
 export `compgen -A variable | grep _ocid | grep _ocid | sed 's/$/=__TO_FILL__/'`
 export TF_VAR_db_password=__TO_FILL__
 export TF_VAR_auth_token=__TO_FILL__
@@ -26,9 +65,9 @@ do
 done
 PARAM_LIST=`echo $PARAM_LIST|sed 's/&$//'`
 
+title "Call OCI Starter Website to get the latest OCI starter script with the same parameters"
 echo "curl -k https://www.ocistarter.com/app/zip?$PARAM_LIST"
 
-UPGRADE_DIR="upgrade$(date +%Y%m%d%H%M%S)"
 
 cd $PROJECT_DIR
 mkdir $UPGRADE_DIR
@@ -38,11 +77,31 @@ unzip upgrade.zip
 rm upgrade.zip
 mv $TF_VAR_prefix/* $TF_VAR_prefix/.*  .
 rmdir $TF_VAR_prefix
-mkdir orig
-mv src orig
-mv env.sh orig
-cp -r ../src .
-cp ../env.sh .
 
-echo
-echo "Upgrade directory created: $UPGRADE_DIR"
+title "Upgrade directory"
+mkdir not_used
+mv src not_used
+echo "Saved upgrade/src to upgrade/not_used/src"
+
+mv env.sh not_used
+echo "Saved upgrade/env.sh to upgrade/not_used/env.sh"
+
+cp -r ../src .
+echo "Replaced the upgrade/src directory by src"
+
+cp ../env.sh .
+echo "Replaced the upgrade/env.sh directory by env.sh"
+
+echo "Done."
+echo 
+echo "Next steps:"
+echo "cd upgrade"
+echo "./starter.sh build"
+echo 
+echo "If OK:"
+echo "cd .."
+echo "mkdir orig"
+echo "mv * orig"
+echo "mv orig/upgrade/* ."
+echo "echo orig > .gitignore" 
+

--- a/basis/src/app/build_app.j2.sh
+++ b/basis/src/app/build_app.j2.sh
@@ -18,6 +18,9 @@ if is_deploy_compute; then
   cp -r src/* ../../target/compute/$APP_DIR/.
   # Replace the user and password in the start file
   replace_db_user_password_in_file ../../target/compute/$APP_DIR/start.sh
+  if [ -f $TARGET_DIR/compute/$APP_DIR/env.sh ]; then 
+    file_replace_variables $TARGET_DIR/compute/$APP_DIR/env.sh
+  fi 
 else
   docker image rm ${TF_VAR_prefix}-app:latest
   docker build -t ${TF_VAR_prefix}-app:latest .

--- a/basis/src/terraform/datasource.tf
+++ b/basis/src/terraform/datasource.tf
@@ -124,7 +124,7 @@ output "oracle-dev-linux-latest-name" {
 */
 
 locals {
-  oracle_linux_latest_name = coalesce( data.oci_core_images.oraclelinux.images.0.display_name, "Oracle-Linux-8.8-2023.10.24-0")
+  oracle_linux_latest_name = coalesce( try(data.oci_core_images.oraclelinux.images.0.display_name, "Oracle-Linux-8.8-2023.10.24-0" ), "Oracle-Linux-8.8-2023.10.24-0")
 }
 
 output "oracle_linux_latest_name" {

--- a/basis/src/terraform/datasource.tf
+++ b/basis/src/terraform/datasource.tf
@@ -124,7 +124,7 @@ output "oracle-dev-linux-latest-name" {
 */
 
 locals {
-  oracle_linux_latest_name = coalesce( try(data.oci_core_images.oraclelinux.images.0.display_name, "Oracle-Linux-8.8-2023.10.24-0" ), "Oracle-Linux-8.8-2023.10.24-0")
+  oracle_linux_latest_name = coalesce( try(data.oci_core_images.oraclelinux.images.0.display_name, "Oracle-Linux-8.10-2025.03.18-0" ), "Oracle-Linux-8.10-2025.03.18-0")
 }
 
 output "oracle_linux_latest_name" {

--- a/option/group/build_group.sh
+++ b/option/group/build_group.sh
@@ -4,7 +4,7 @@ cd $SCRIPT_DIR
 
 cd group_common
 . bin/shared_bash_function.sh
-./starter.sh build
+./starter.sh build ${@}
 exit_on_error
 cd $SCRIPT_DIR
 
@@ -13,7 +13,7 @@ for d in `ls -d */ | sort -g`; do
       echo "-- BUILD_ALL - $d ---------------------------------"
 
       cd $d
-      ./starter.sh build
+      ./starter.sh build ${@}
       exit_on_error
       cd $SCRIPT_DIR
     fi

--- a/option/src/app/ords/db/oracle.sql
+++ b/option/src/app/ords/db/oracle.sql
@@ -1,6 +1,25 @@
 -- XXXX This is a very bad practice to use the ADMIN user.
 -- XXXX Should create a user scott and replace connect string with SCOTT ?
 -- DROP TABLE DEPT;
+CREATE USER starter IDENTIFIED BY &1;
+GRANT "CONNECT" TO starter;
+GRANT "RESOURCE" TO starter;
+GRANT UNLIMITED TABLESPACE TO starter;
+
+BEGIN
+  ORDS.enable_schema(
+    p_enabled             => TRUE,
+    p_schema              => 'starter',
+    p_url_mapping_type    => 'BASE_PATH',
+    p_url_mapping_pattern => 'starter',
+    p_auto_rest_auth      => FALSE
+  );  
+  COMMIT;
+END;
+/
+
+connect starter/&1@DB
+
 CREATE TABLE DEPT
        (DEPTNO NUMBER PRIMARY KEY,
         DNAME VARCHAR2(64),
@@ -12,17 +31,7 @@ INSERT INTO DEPT VALUES (30, 'SALES',      'CHICAGO');
 INSERT INTO DEPT VALUES (40, 'OPERATIONS', 'BOSTON');
 COMMIT;
 
-BEGIN
-  ORDS.enable_schema(
-    p_enabled             => TRUE,
-    p_schema              => 'ADMIN',
-    p_url_mapping_type    => 'BASE_PATH',
-    p_url_mapping_pattern => 'starter',
-    p_auto_rest_auth      => FALSE
-  );  
-  COMMIT;
-END;
-/
+
 BEGIN
   ORDS.define_module(
     p_module_name    => 'module',

--- a/option/src/app/python/src/install.j2.sh
+++ b/option/src/app/python/src/install.j2.sh
@@ -8,11 +8,11 @@ cd $SCRIPT_DIR
 sudo yum -y install postgresql-devel 
 {%- endif %}
 
-sudo dnf install -y python3.11 python3.11-pip python3-devel
-sudo pip3.11 install pip --upgrade
+sudo dnf install -y python3.12 python3.12-pip python3-devel
+sudo pip3.12 install pip --upgrade
 
 # Install virtual env python_env
-python3.11 -m venv myenv
+python3.12 -m venv myenv
 source myenv/bin/activate
 pip3 install --upgrade pip
 pip3 install -r requirements.txt

--- a/option/src/db/oracle/db_init.sh
+++ b/option/src/db/oracle/db_init.sh
@@ -17,4 +17,4 @@ DB  = $DB_URL
 EOT
 
 export TNS_ADMIN=$SCRIPT_DIR
-sqlplus -L $DB_USER/$DB_PASSWORD@DB @oracle.sql
+sqlplus -L $DB_USER/$DB_PASSWORD@DB @oracle.sql $DB_PASSWORD

--- a/option/terraform/bastion.j2.tf
+++ b/option/terraform/bastion.j2.tf
@@ -87,6 +87,12 @@ resource "oci_core_instance" "starter_bastion" {
     private_key = var.ssh_private_key
   }
 
+  lifecycle {
+    ignore_changes = [
+      source_details[0].source_id
+    ]
+  }
+
   freeform_tags = local.freeform_tags   
 }
 

--- a/option/terraform/compute.j2.tf
+++ b/option/terraform/compute.j2.tf
@@ -60,6 +60,12 @@ resource "oci_core_instance" "starter_compute" {
     private_key = var.ssh_private_key
   }
 
+  lifecycle {
+    ignore_changes = [
+      source_details[0].source_id
+    ]
+  }
+  
   freeform_tags = local.freeform_tags
 }
 

--- a/option/terraform/dbsystem.j2.tf
+++ b/option/terraform/dbsystem.j2.tf
@@ -66,6 +66,12 @@ resource "oci_database_db_system" "starter_dbsystem" {
   license_model           = var.license_model
   node_count              = ##db_node_count##
 
+  lifecycle {
+    ignore_changes = [
+      db_home[0].db_version
+    ]
+  }
+
   freeform_tags = local.freeform_tags
 }
 

--- a/test_suite/test_suite_shared.sh
+++ b/test_suite/test_suite_shared.sh
@@ -66,7 +66,7 @@ build_test () {
   cd $TEST_HOME
   cd $TEST_DIR
   pwd
-  ./starter.sh build > build_$BUILD_ID.log 2>&1
+  ./starter.sh build --auto-approve > build_$BUILD_ID.log 2>&1
 
   CSV_NAME=$NAME
   CSV_DIR=$TEST_DIR
@@ -375,7 +375,7 @@ pre_test_suite() {
   cd $TEST_HOME/group_common
   echo "# Test Suite use 2 nodes to avoid error: Too Many Pods (110 pods/node K8s limit)" >> env.sh
   echo "export TF_VAR_node_pool_size=2" >> env.sh
-  ./starter.sh build
+  ./starter.sh build --auto-approve
   exit_on_error
   date
   echo "CSV_DATE,OPTION_DEPLOY,OPTION_LANG,OPTION_JAVA_FRAMEWORK,OPTION_JAVA_VM,OPTION_DB,OPTION_DB_INSTALL,OPTION_UI,OPTION_SHAPE,CSV_NAME,CSV_HTML_OK,CSV_JSON_OK,CSV_BUILD_SECOND,CSV_DESTROY_SECOND,CSV_RUN100_OK,CSV_RUN100_SECOND" > $TEST_HOME/result.csv 

--- a/test_suite/test_suite_shared.sh
+++ b/test_suite/test_suite_shared.sh
@@ -222,7 +222,14 @@ build_option() {
      ./starter.sh destroy --auto-approve > destroy_before_refresh.log 2>&1  
   fi
 
+  # Prevent to start test build if the group_common was not finished
+  if [ ! -f $TEST_HOME/group_common_env.sh]; then
+    echo "ERROR: $TEST_HOME/group_common_env.sh not found"
+    exit 1
+  fi 
+
   add_inprogress_rerun
+
 
   # Avoid 2 parallel creations of code
   while [ -f $TEST_HOME/oci_starter_busy ]; do

--- a/test_suite/test_suite_shared.sh
+++ b/test_suite/test_suite_shared.sh
@@ -223,7 +223,7 @@ build_option() {
   fi
 
   # Prevent to start test build if the group_common was not finished
-  if [ ! -f $TEST_HOME/group_common_env.sh]; then
+  if [ ! -f $TEST_HOME/group_common_env.sh ]; then
     echo "ERROR: $TEST_HOME/group_common_env.sh not found"
     exit 1
   fi 

--- a/test_suite/test_suite_shared.sh
+++ b/test_suite/test_suite_shared.sh
@@ -292,7 +292,7 @@ build_option() {
        -auth_token $OCI_TOKEN \
        -apigw_ocid $TF_VAR_apigw_ocid \
        -bastion_ocid $TF_VAR_bastion_ocid \
-       -fnapp_ocid $TF_VAR_fnapp_ocid > ${TEST_DIR}.log 2>&1 
+       -fnapp_ocid $TF_VAR_fnapp_ocid >> ${TEST_DIR}.log 2>&1 
   else
     # Unique name to allow more generations of TLS certificates. The prefix is used as hostname for TLS http_01.
     OPTION_TSONE_ID=$((OPTION_TSONEID+1))


### PR DESCRIPTION
Changes
---------
- ./starter build  request to approve change in the second build.
- ./starter destroy remove the .terraform cache after destroy ( 250Mb big...)
- file_replace_variables for ##XXX## app/env.sh and compute (not used yet per default)
- upgrade.sh improved
- default Oracle Linux in case of no access to images list : Oracle-Linux-8.10-2025.03.18-0
- ords fix using not the ADMIN schema anymore
- python 3.11 -> 3.12
- terraform lifecycle / ignore_changes for Linux image name new version, etc..