### PR TITLE
3.9

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -107,3 +107,9 @@ Date 7-Apr-2025
 Date 14-Apr-2025
 - done.sh splitted in done.sh and test_after_done.sh
 - upgrade.sh 2.0 -> 3.x 
+
+3.8
+---
+Date 13-May-2025
+- container repository in compartment (repository.tf) for Kubernetes, Container Instance, Function
+- container repository random prefix

--- a/basis/bin/auto_env.sh
+++ b/basis/bin/auto_env.sh
@@ -133,7 +133,7 @@ else
      if grep -q "VM.Standard.x86.Generic" $TARGET_DIR/shapes.list; then
        auto_echo "Fungible shape VM.Standard.x86.Generic found"
      else
-       export TF_VAR_instance_shape="VM.Standard.E4.Flex"
+       guess_available_shape
        echo "Warning: fungible shape VM.Standard.x86.Generic not found. Using $TF_VAR_instance_shape"
      fi
   fi
@@ -153,10 +153,12 @@ else
   # DATE_POSTFIX (used for logs names)
   DATE_POSTFIX=`date '+%Y%m%d-%H%M%S'`
 
+  # Namespace
+  export TF_VAR_namespace=`oci os ns get | jq -r .data`
+  auto_echo TF_VAR_namespace=$TF_VAR_namespace
+
   # Kubernetes and OCIR
   if [ "$TF_VAR_deploy_type" == "kubernetes" ] || [ "$TF_VAR_deploy_type" == "function" ] || [ "$TF_VAR_deploy_type" == "container_instance" ] || [ -f $PROJECT_DIR/src/terraform/oke.tf ]; then
-    export TF_VAR_namespace=`oci os ns get | jq -r .data`
-    auto_echo TF_VAR_namespace=$TF_VAR_namespace
     export TF_VAR_email=mail@domain.com
     auto_echo TF_VAR_email=$TF_VAR_email
     # ex: OCIR region is using the key prefix: fra.ocir.io

--- a/basis/bin/build_all.sh
+++ b/basis/bin/build_all.sh
@@ -9,15 +9,6 @@ SECONDS=0
 . starter.sh env -no-auto
 title "OCI Starter - Build"
 
-# First build is auto-approved. Else you need to pass --auto-approve flag.
-if [ "$1" == "--auto-approve" ]; then
-   export TERRAFORM_FLAG="--auto-approve"
-elif [ -f $STATE_FILE ]; then
-   echo "$STATE_FILE detected."
-else
-   export TERRAFORM_FLAG="--auto-approve"
-fi
-
 # Custom code before build
 if [ -f $PROJECT_DIR/src/before_build.sh ]; then
   $PROJECT_DIR/src/before_build.sh
@@ -36,7 +27,7 @@ if [ "$TF_VAR_tls" != "" ]; then
 fi  
 
 title "Terraform Apply"
-$BIN_DIR/terraform_apply.sh -no-color $TERRAFORM_FLAG
+$BIN_DIR/terraform_apply.sh $1 -no-color 
 exit_on_error
 
 . starter.sh env

--- a/basis/bin/config.sh
+++ b/basis/bin/config.sh
@@ -175,7 +175,10 @@ if declare -p | grep -q "__TO_FILL__"; then
   fi  
 
   # Livelabs Green Button (Autodetect compartment/vcn/subnet)
-  livelabs_green_button
+  livelabs_green_button 
+
+  # LunaLab (Autodetect compartment)
+  lunalab
 
   # COMPARTMENT_ID
   if [ "$TF_VAR_compartment_ocid" == "__TO_FILL__" ]; then
@@ -210,8 +213,21 @@ if declare -p | grep -q "__TO_FILL__"; then
     fi     
     # echo "        The components will be created in the root compartment."
     # export TF_VAR_compartment_ocid=$TF_VAR_tenancy_ocid
-
   fi
+  
+  # Vault
+  if [ "$TF_VAR_vault_ocid" == "__TO_FILL__" ]; then
+    title "Config - Vault"       
+    export REQUEST="Create a new vault ? (<No> will ask for the ocid of an existing one) ?"
+    if accept_request; then  
+      read_ocid TF_VAR_vault_ocid "Vault" ocid1.vault
+      read_ocid TF_VAR_vault_key_ocid "Vault" ocid1.key
+    else
+      # Comment the 2 line. The vault will be created.
+      sed -i "s/^export TF_VAR_vault_ocid/#export TF_VAR_vault_ocid/" $PROJECT_DIR/env.sh     
+      sed -i "s/^export TF_VAR_vault_key_ocid/#export TF_VAR_vault_key_ocid/" $PROJECT_DIR/env.sh     
+    fi     
+  fi    
 
   # OCIDs
   read_ocid TF_VAR_vcn_ocid "Virtual Cloud Network (VCN)" ocid1.vcn 

--- a/basis/bin/done.sh
+++ b/basis/bin/done.sh
@@ -27,10 +27,10 @@ elif [ ! -z "$UI_URL" ]; then
     if [ -f  $PROJECT_DIR/src/$APP_DIR/openapi_spec.yaml ]; then
       # - does not work anymore - python3 $BIN_DIR/openapi_list.py $PROJECT_DIR/src/$APP_DIR/openapi_spec.yaml $UI_URL
       # Show the list of paths in the openapi_spec.yaml 
-      grep "^[[:space:]]*/.*:" $PROJECT_DIR/src/$APP_DIR/openapi_spec.yaml | sed "s#[[:space:]]*##" | sed "s/://" | sed  "s#^#- $UI_URL#"
+      grep "^[[:space:]]*/.*:" $PROJECT_DIR/src/$APP_DIR/openapi_spec.yaml | sed "s#[[:space:]]*##" | sed "s/://" | sed  "s#^#- Rest API: $UI_URL#"
     fi  
-    # echo - Rest DB API     : $UI_URL/$APP_DIR/dept
-    # echo - Rest Info API   : $UI_URL/$APP_DIR/info
+    # echo - Rest API: $UI_URL/$APP_DIR/dept
+    # echo - Rest API: $UI_URL/$APP_DIR/info
   done
   if [[ ("$TF_VAR_deploy_type" == "public_compute" || "$TF_VAR_deploy_type" == "private_compute") && "$TF_VAR_ui_type" == "api" ]]; then   
     export APIGW_URL=https://${APIGW_HOSTNAME}/${TF_VAR_prefix}  

--- a/basis/bin/done.sh
+++ b/basis/bin/done.sh
@@ -25,7 +25,9 @@ elif [ ! -z "$UI_URL" ]; then
   fi
   for APP_DIR in `app_dir_list`; do
     if [ -f  $PROJECT_DIR/src/$APP_DIR/openapi_spec.yaml ]; then
-      python3 $BIN_DIR/openapi_list.py $PROJECT_DIR/src/$APP_DIR/openapi_spec.yaml $UI_URL
+      # - does not work anymore - python3 $BIN_DIR/openapi_list.py $PROJECT_DIR/src/$APP_DIR/openapi_spec.yaml $UI_URL
+      # Show the list of paths in the openapi_spec.yaml 
+      grep "^[[:space:]]*/.*:" $PROJECT_DIR/src/$APP_DIR/openapi_spec.yaml | sed "s#[[:space:]]*##" | sed "s/://" | sed  "s/^/- $UI_URL/"
     fi  
     # echo - Rest DB API     : $UI_URL/$APP_DIR/dept
     # echo - Rest Info API   : $UI_URL/$APP_DIR/info

--- a/basis/bin/done.sh
+++ b/basis/bin/done.sh
@@ -27,7 +27,7 @@ elif [ ! -z "$UI_URL" ]; then
     if [ -f  $PROJECT_DIR/src/$APP_DIR/openapi_spec.yaml ]; then
       # - does not work anymore - python3 $BIN_DIR/openapi_list.py $PROJECT_DIR/src/$APP_DIR/openapi_spec.yaml $UI_URL
       # Show the list of paths in the openapi_spec.yaml 
-      grep "^[[:space:]]*/.*:" $PROJECT_DIR/src/$APP_DIR/openapi_spec.yaml | sed "s#[[:space:]]*##" | sed "s/://" | sed  "s/^/- $UI_URL/"
+      grep "^[[:space:]]*/.*:" $PROJECT_DIR/src/$APP_DIR/openapi_spec.yaml | sed "s#[[:space:]]*##" | sed "s/://" | sed  "s#^#- $UI_URL#"
     fi  
     # echo - Rest DB API     : $UI_URL/$APP_DIR/dept
     # echo - Rest Info API   : $UI_URL/$APP_DIR/info

--- a/basis/bin/shared_bash_function.sh
+++ b/basis/bin/shared_bash_function.sh
@@ -56,7 +56,7 @@ build_function() {
   fn update context oracle.compartment-id ${TF_VAR_compartment_ocid}
   fn update context api-url https://functions.${TF_VAR_region}.oraclecloud.com
   fn update context registry ${DOCKER_PREFIX}
-  # Set pipefail to get the error despite pip to tee
+  # Set pipefail to get the error despite pipe to tee
   set -o pipefail
   fn build -v | tee $TARGET_DIR/fn_build.log
   exit_on_error
@@ -214,6 +214,25 @@ find_availabilty_domain_for_shape() {
   done
   echo "Error shape $1 not found" 
   exit 1
+}
+
+# Guess the shape E6/E5/E4
+guess_available_shape() {
+  echo "Guessing compute shape..."  
+  i=1
+  for ad in `oci iam availability-domain list --compartment-id=$TF_VAR_tenancy_ocid | jq -r ".data[].name"` 
+  do
+    for s in VM.Standard.E6.Flex VM.Standard.E5.Flex VM.Standard.E4.Flex; do
+      TEST=`oci compute shape list --compartment-id=$TF_VAR_tenancy_ocid --availability-domain $ad | jq ".data[] | select( .shape==\"$s\" )"`
+      if [[ "$TEST" != "" ]]; then
+        echo "Found Shape $s in $ad"
+        export TF_VAR_instance_shape=$s
+        return 0
+      fi
+    done  
+    i=$((i+1))
+  done
+  error_exit "Error no shape not found" 
 }
 
 # Get User Details (username and OCID)
@@ -391,6 +410,18 @@ livelabs_green_button() {
     # fi
 
   fi
+}
+
+lunalab() {
+  if grep -q 'export TF_VAR_compartment_ocid="__TO_FILL__"' $PROJECT_DIR/env.sh; then    
+    if [ $USER = "luna.user" ]; then
+        echo "LunaLab - Luna User detected"
+    else
+        return
+    fi    
+    export TF_VAR_compartment_ocid=$OCI_COMPARTMENT_OCID
+    export TF_VAR_instance_shape="VM.Standard.E5.Flex"
+  fi 
 }
 
 create_deployment_in_apigw() {

--- a/basis/bin/shared_bash_function.sh
+++ b/basis/bin/shared_bash_function.sh
@@ -218,7 +218,7 @@ find_availabilty_domain_for_shape() {
 
 # Guess the shape E6/E5/E4
 guess_available_shape() {
-  if [ $TARGET_DIR/shape.json ]; then  
+  if [ -f $TARGET_DIR/shape.json ]; then  
     export TF_VAR_instance_shape=`cat $TARGET_DIR/shape.json`
     echo "Reading shape from $TARGET_DIR/shape.json ($TF_VAR_instance_shape)"
   else
@@ -232,7 +232,7 @@ guess_available_shape() {
         if [[ "$TEST" != "" ]]; then
             echo "Found Shape $s in $ad"
             export TF_VAR_instance_shape=$s
-            echo TF_VAR_instance_shape > $TARGET_DIR/shape.json
+            echo $TF_VAR_instance_shape > $TARGET_DIR/shape.json
             return 0
         fi
         done  

--- a/basis/bin/shared_bash_function.sh
+++ b/basis/bin/shared_bash_function.sh
@@ -218,21 +218,28 @@ find_availabilty_domain_for_shape() {
 
 # Guess the shape E6/E5/E4
 guess_available_shape() {
-  echo "Guessing compute shape..."  
-  i=1
-  for ad in `oci iam availability-domain list --compartment-id=$TF_VAR_tenancy_ocid | jq -r ".data[].name"` 
-  do
-    for s in VM.Standard.E6.Flex VM.Standard.E5.Flex VM.Standard.E4.Flex; do
-      TEST=`oci compute shape list --compartment-id=$TF_VAR_tenancy_ocid --availability-domain $ad | jq ".data[] | select( .shape==\"$s\" )"`
-      if [[ "$TEST" != "" ]]; then
-        echo "Found Shape $s in $ad"
-        export TF_VAR_instance_shape=$s
-        return 0
-      fi
-    done  
-    i=$((i+1))
-  done
-  error_exit "Error no shape not found" 
+  if [ $TARGET_DIR/shape.json ]; then  
+    export TF_VAR_instance_shape=`cat $TARGET_DIR/shape.json`
+    echo "Reading shape from $TARGET_DIR/shape.json ($TF_VAR_instance_shape)"
+  else
+    echo "Searching for compute shape..."  
+    i=1
+    for ad in `oci iam availability-domain list --compartment-id=$TF_VAR_tenancy_ocid | jq -r ".data[].name"` 
+    do
+        oci compute shape list --compartment-id=$TF_VAR_tenancy_ocid --availability-domain $ad > $TARGET_DIR/shapes.json
+        for s in VM.Standard.E6.Flex VM.Standard.E5.Flex VM.Standard.E4.Flex; do
+        TEST=`cat $TARGET_DIR/shapes.json | jq ".data[] | select( .shape==\"$s\" )"`
+        if [[ "$TEST" != "" ]]; then
+            echo "Found Shape $s in $ad"
+            export TF_VAR_instance_shape=$s
+            echo TF_VAR_instance_shape > $TARGET_DIR/shape.json
+            return 0
+        fi
+        done  
+        i=$((i+1))
+    done
+    error_exit "Error no shape not found" 
+  fi
 }
 
 # Get User Details (username and OCID)

--- a/basis/bin/shared_infra_as_code.sh
+++ b/basis/bin/shared_infra_as_code.sh
@@ -26,9 +26,11 @@ infra_as_code_plan() {
 # Before to run the build check the some resource with unique name in the tenancy does not exists already
 infra_as_code_precheck() {
   title "Precheck"
+  cd $PROJECT_DIR/src/terraform 
+  $TERRAFORM_COMMAND init -no-color -upgrade  
   $TERRAFORM_COMMAND plan -json -out=$TARGET_DIR/tfplan.out
   # Buckets
-  LIST_BUCKETS=`$TERRAFORM_COMMAND show -json $TARGET_DIR/tfplan.out | jq '.resource_changes[] | select(.change.actions[] == "create") | .address' | grep "oci_objectstorage_bucket"` 
+  LIST_BUCKETS=`$TERRAFORM_COMMAND show -json $TARGET_DIR/tfplan.out 2>/dev/null | jq '.resource_changes[] | select(.change.actions[] == "create") | .address' | grep "oci_objectstorage_bucket"` 
   for BUCKET_NAME in `LIST_BUCKETS`; do
     BUCKET_CHECK=`oci os bucket get --bucket-name $BUCKET_NAME --namespace-name $TF_VAR_namespace | jq -r .data.name`
     if [ "$BUCKET_NAME" == "$BUCKET_CHECK" ]; then

--- a/basis/bin/shared_infra_as_code.sh
+++ b/basis/bin/shared_infra_as_code.sh
@@ -43,7 +43,7 @@ infra_as_code_precheck() {
        echo  
        echo "export TF_VAR_PREFIX=xxx123"
        echo  
-       exit
+       error_exit
   fi
   done
 }

--- a/basis/bin/shared_infra_as_code.sh
+++ b/basis/bin/shared_infra_as_code.sh
@@ -28,10 +28,11 @@ infra_as_code_precheck() {
   title "Precheck"
   cd $PROJECT_DIR/src/terraform 
   $TERRAFORM_COMMAND init -no-color -upgrade  
-  $TERRAFORM_COMMAND plan -json -out=$TARGET_DIR/tfplan.out
+  $TERRAFORM_COMMAND plan -json -out=$TARGET_DIR/tfplan.out > /dev/null
   # Buckets
-  LIST_BUCKETS=`$TERRAFORM_COMMAND show -json $TARGET_DIR/tfplan.out | jq '.resource_changes[] | select(.change.actions[] == "create") | .address' | grep "oci_objectstorage_bucket"` 
-  for BUCKET_NAME in `LIST_BUCKETS`; do
+  LIST_BUCKETS=`$TERRAFORM_COMMAND show -json $TARGET_DIR/tfplan.out | jq -r '.resource_changes[] | select(.type == "oci_objectstorage_bucket") | .name'`
+  for BUCKET_NAME in $LIST_BUCKETS; do
+    echo "Checking if bucket $BUCKET_NAME exists"
     BUCKET_CHECK=`oci os bucket get --bucket-name $BUCKET_NAME --namespace-name $TF_VAR_namespace | jq -r .data.name`
     if [ "$BUCKET_NAME" == "$BUCKET_CHECK" ]; then
        echo "PRECHECK ERROR: Bucket $BUCKET_NAME exists already in this tenancy."
@@ -44,7 +45,7 @@ infra_as_code_precheck() {
        echo "export TF_VAR_PREFIX=xxx123"
        echo  
        error_exit
-  fi
+    fi
   done
 }
 

--- a/basis/bin/shared_infra_as_code.sh
+++ b/basis/bin/shared_infra_as_code.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
+# - 2025-06_17 : added Tofu support for LunaLab
 set -e
+
+if command -v terraform  &> /dev/null; then
+  export TERRAFORM_COMMAND=terraform
+elif command -v tofu  &> /dev/null; then
+  export TERRAFORM_COMMAND=tofu
+else
+  error_exit "Command not found: terraform or tofu"
+fi     
 
 infra_as_code_plan() {
   cd $PROJECT_DIR/src/terraform    
@@ -9,9 +18,32 @@ infra_as_code_plan() {
     if [ "$TF_VAR_infra_as_code" == "terraform_object_storage" ]; then
       sed "s/XX_TERRAFORM_STATE_URL_XX/$TF_VAR_terraform_state_url/g" terraform.template.tf > terraform/terraform.tf
     fi  
-    terraform init -no-color
-    terraform plan
+    $TERRAFORM_COMMAND init -no-color -upgrade
+    $TERRAFORM_COMMAND plan
   fi
+}
+
+# Before to run the build check the some resource with unique name in the tenancy does not exists already
+infra_as_code_precheck() {
+  title "Precheck"
+  $TERRAFORM_COMMAND plan -json -out=$TARGET_DIR/tfplan.out
+  # Buckets
+  LIST_BUCKETS=`$TERRAFORM_COMMAND show -json $TARGET_DIR/tfplan.out | jq '.resource_changes[] | select(.change.actions[] == "create") | .address' | grep "oci_objectstorage_bucket"` 
+  for BUCKET_NAME in `LIST_BUCKETS`; do
+    BUCKET_CHECK=`oci os bucket get --bucket-name $BUCKET_NAME --namespace-name $TF_VAR_namespace | jq -r .data.name`
+    if [ "$BUCKET_NAME" == "$BUCKET_CHECK" ]; then
+       echo "PRECHECK ERROR: Bucket $BUCKET_NAME exists already in this tenancy."
+       echo
+       echo "Solution: There is probably another installation on this tenancy with the same prefix."
+       echo "If you want to create a new installation, "
+       echo "- edit the file env.sh"
+       echo "- put a unique prefix in TF_VAR_PREFIX. Ex:"
+       echo  
+       echo "export TF_VAR_PREFIX=xxx123"
+       echo  
+       exit
+  fi
+  done
 }
 
 infra_as_code_apply() {
@@ -24,8 +56,8 @@ infra_as_code_apply() {
     if [ "$TF_VAR_infra_as_code" == "terraform_object_storage" ]; then
       sed "s/XX_TERRAFORM_STATE_URL_XX/$TF_VAR_terraform_state_url/g" terraform.template.tf > terraform/terraform.tf
     fi  
-    terraform init -no-color -upgrade
-    terraform apply $@
+    $TERRAFORM_COMMAND init -no-color -upgrade
+    $TERRAFORM_COMMAND apply $@
     exit_on_error
   fi
 }
@@ -35,8 +67,8 @@ infra_as_code_destroy() {
   if [ "$TF_VAR_infra_as_code" == "resource_manager" ]; then
     resource_manager_destroy
   else
-    terraform init -upgrade
-    terraform destroy $@
+    $TERRAFORM_COMMAND init -upgrade
+    $TERRAFORM_COMMAND destroy $@
   fi
 }
 

--- a/basis/bin/shared_infra_as_code.sh
+++ b/basis/bin/shared_infra_as_code.sh
@@ -25,15 +25,15 @@ infra_as_code_plan() {
 
 # Before to run the build check the some resource with unique name in the tenancy does not exists already
 infra_as_code_precheck() {
-  title "Precheck"
+  echo "-- Precheck"
   cd $PROJECT_DIR/src/terraform 
   $TERRAFORM_COMMAND init -no-color -upgrade  
   $TERRAFORM_COMMAND plan -json -out=$TARGET_DIR/tfplan.out > /dev/null
   # Buckets
   LIST_BUCKETS=`$TERRAFORM_COMMAND show -json $TARGET_DIR/tfplan.out | jq -r '.resource_changes[] | select(.type == "oci_objectstorage_bucket") | .name'`
   for BUCKET_NAME in $LIST_BUCKETS; do
-    echo "Checking if bucket $BUCKET_NAME exists"
-    BUCKET_CHECK=`oci os bucket get --bucket-name $BUCKET_NAME --namespace-name $TF_VAR_namespace | jq -r .data.name`
+    echo "Precheck if bucket $BUCKET_NAME exists"
+    BUCKET_CHECK=`oci os bucket get --bucket-name $BUCKET_NAME --namespace-name $TF_VAR_namespace 2> /dev/null | jq -r .data.name`
     if [ "$BUCKET_NAME" == "$BUCKET_CHECK" ]; then
        echo "PRECHECK ERROR: Bucket $BUCKET_NAME exists already in this tenancy."
        echo

--- a/basis/bin/shared_infra_as_code.sh
+++ b/basis/bin/shared_infra_as_code.sh
@@ -30,7 +30,7 @@ infra_as_code_precheck() {
   $TERRAFORM_COMMAND init -no-color -upgrade  
   $TERRAFORM_COMMAND plan -json -out=$TARGET_DIR/tfplan.out
   # Buckets
-  LIST_BUCKETS=`$TERRAFORM_COMMAND show -json $TARGET_DIR/tfplan.out 2>/dev/null | jq '.resource_changes[] | select(.change.actions[] == "create") | .address' | grep "oci_objectstorage_bucket"` 
+  LIST_BUCKETS=`$TERRAFORM_COMMAND show -json $TARGET_DIR/tfplan.out | jq '.resource_changes[] | select(.change.actions[] == "create") | .address' | grep "oci_objectstorage_bucket"` 
   for BUCKET_NAME in `LIST_BUCKETS`; do
     BUCKET_CHECK=`oci os bucket get --bucket-name $BUCKET_NAME --namespace-name $TF_VAR_namespace | jq -r .data.name`
     if [ "$BUCKET_NAME" == "$BUCKET_CHECK" ]; then

--- a/basis/bin/start_stop.sh
+++ b/basis/bin/start_stop.sh
@@ -26,10 +26,11 @@ function loop_resource() {
                 oci db autonomous-database $ACTION --autonomous-database-id $OCID
             elif [ "$RESOURCE_TYPE" == "oci_database_db_system" ]; then
                 COMPARTMENT_ID=`oci db system get --db-system-id $OCID | jq -r '.data["compartment-id"]'`
-                NODES=$(oci db node --all --compartment-id $COMPARTMENT_ID --db-system-id $OCID | jq -r '.data[].id')
+                NODES=$(oci db node list --all --compartment-id $COMPARTMENT_ID --db-system-id $OCID | jq -r '.data[].id')
+                echo NODES=$NODES
                 for NODE in $NODES
                 do            
-                    oci db node stop --db-node-id $NODE
+                    oci db node $ACTION --db-node-id $NODE
                 done            
             elif [ "$RESOURCE_TYPE" == "oci_datascience_notebook_session" ]; then
                 if [ "$ACTION" == "start" ]; then
@@ -40,7 +41,11 @@ function loop_resource() {
             elif [ "$RESOURCE_TYPE" == "oci_integration_integration_instance" ]; then
                 oci integration integration-instance $ACTION --id $OCID
             elif [ "$RESOURCE_TYPE" == "oci_mysql_mysql_db_system" ]; then
-                oci mysql db-system $ACTION --db-system-id $OCID --shutdown-type innodb_fast_shutdown 
+                if [ "$ACTION" == "start" ]; then
+                    oci mysql db-system $ACTION --db-system-id $OCID 
+                else
+                    oci mysql db-system $ACTION --db-system-id $OCID --shutdown-type innodb_fast_shutdown 
+                fi
             elif [ "$RESOURCE_TYPE" == "oci_oda_oda_instance" ]; then
                 oci oda instance $ACTION --oda-instance-id $OCID
             fi

--- a/basis/bin/starter.sh
+++ b/basis/bin/starter.sh
@@ -27,7 +27,7 @@ if [ -z $ARG1 ]; then
     rm $COMMAND_FILE
   fi
   if [ ! -f $COMMAND_FILE ]; then
-    python $BIN_DIR/starter_menu.py 
+    python3 $BIN_DIR/starter_menu.py 
     if [ -f $COMMAND_FILE ]; then
       COMMAND=$(cat $COMMAND_FILE)
       rm $COMMAND_FILE
@@ -99,6 +99,27 @@ elif [ "$ARG1" == "ssh" ]; then
   else 
     echo "Unknown command: $ARG1 $ARG2"
   fi    
+elif [ "$ARG1" == "rebuild" ]; then
+  . $BIN_DIR/shared_bash_function.sh
+
+  # Destroy
+  LOG_NAME=$TARGET_DIR/logs/destroy.${DATE_POSTFIX}.log
+  ln -sf $LOG_NAME $TARGET_DIR/destroy.log
+  $BIN_DIR/destroy_all.sh ${@:2} 2>&1 | tee $LOG_NAME
+  exit_on_error
+  
+  # Pull
+  git pull
+  exit_on_error
+  
+  # Cleanup target dir
+  rm -Rf $TARGET_DIR
+  mkdir -p $TARGET_DIR/logs
+
+  # Build
+  LOG_NAME=$TARGET_DIR/logs/build.${DATE_POSTFIX}.log
+  ln -sf $LOG_NAME $TARGET_DIR/build.log  
+  $BIN_DIR/build_all.sh ${@:2} 2>&1 | tee $LOG_NAME
 elif [ "$ARG1" == "terraform" ]; then
   if [ "$ARG2" == "plan" ]; then
     $BIN_DIR/terraform_plan.sh ${@:3}

--- a/basis/bin/terraform_apply.sh
+++ b/basis/bin/terraform_apply.sh
@@ -8,5 +8,16 @@ cd $PROJECT_DIR
 . starter.sh env -silent
 . $BIN_DIR/shared_infra_as_code.sh
 cd $PROJECT_DIR/src/terraform
+
+# First build is auto-approved. Else you need to pass --auto-approve flag.
+if [ "$1" == "--auto-approve" ]; then
+  export TERRAFORM_FLAG="--auto-approve"
+elif [ -f $STATE_FILE ]; then
+  echo "$STATE_FILE detected."
+else
+  infra_as_code_precheck
+  export TERRAFORM_FLAG="--auto-approve"
+fi
+
 infra_as_code_apply $@
 exit_on_error

--- a/basis/bin/terraform_apply.sh
+++ b/basis/bin/terraform_apply.sh
@@ -16,10 +16,8 @@ elif [ -f $STATE_FILE ]; then
   echo "$STATE_FILE detected."
 else
   infra_as_code_precheck
-  # Remove empty STATE_FILE
-  rm $STATE_FILE
   export TERRAFORM_FLAG="--auto-approve"
 fi
 
-infra_as_code_apply $@
+infra_as_code_apply $TERRAFORM_FLAG $@
 exit_on_error

--- a/basis/bin/terraform_apply.sh
+++ b/basis/bin/terraform_apply.sh
@@ -16,6 +16,8 @@ elif [ -f $STATE_FILE ]; then
   echo "$STATE_FILE detected."
 else
   infra_as_code_precheck
+  # Remove empty STATE_FILE
+  rm $STATE_FILE
   export TERRAFORM_FLAG="--auto-approve"
 fi
 

--- a/basis/bin/upgrade.sh
+++ b/basis/bin/upgrade.sh
@@ -92,16 +92,16 @@ export LINE_OCI_STARTER_VERSION=`grep "export OCI_STARTER_VERSION" env.sh`
 title "Upgrade directory"
 mkdir not_used
 mv src not_used
-echo "Saved upgrade/src to upgrade/not_used/src"
+echo "Saved $UPGRADE_DIR/src to $UPGRADE_DIR/not_used/src"
 
 mv env.sh not_used
-echo "Saved upgrade/env.sh to upgrade/not_used/env.sh"
+echo "Saved $UPGRADE_DIR/env.sh to $UPGRADE_DIR/not_used/env.sh"
 
 cp -r ../src .
-echo "Replaced the upgrade/src directory by src"
+echo "Replaced the $UPGRADE_DIR/src directory by src"
 
 cp ../env.sh .
-echo "Replaced the upgrade/env.sh directory by env.sh"
+echo "Replaced the $UPGRADE_DIR/env.sh directory by env.sh"
 
 # Remove lines in env.sh
 title "Removing unneeded lines in env.sh"
@@ -153,6 +153,12 @@ if [ -f ../build.sh ]; then
   echo './starter.sh build $@' > build.sh
   echo './starter.sh destroy $@' > destroy.sh
   chmod 755 *.sh
+fi
+
+# Repository.tf
+if [ ! -f src/terraform/repository.tf ]; then
+  cp not_used/src/terraform/repository.tf src/terraform/.
+  echo "Container Repository in compartment: copied the new file repository.tf"
 fi
 
 echo "Done. New version in directory upgrade"

--- a/option/compute/compute_init.sh
+++ b/option/compute/compute_init.sh
@@ -81,41 +81,49 @@ for APP_DIR in `ls -d app* | sort -g`; do
   fi  
 done
 
-# -- app/start.sh -----------------------------------------------------------
+# -- app/start*.sh -----------------------------------------------------------
 for APP_DIR in `ls -d app* | sort -g`; do
-  if [ -f $APP_DIR/start.sh ]; then
-    echo "-- $APP_DIR: Start -----------------------------------------"
+  echo "#!/bin/bash" > $APP_DIR/restart.sh 
+  chmod +x $APP_DIR/restart.sh  
+  for START_SH in `ls $APP_DIR/start*.sh | sort -g`; do
+    echo "-- $START_SH ---------------------------------------"
+    if [[ "$START_SH" =~ start_(.*).sh ]]; then
+      APP_NAME=$(echo "$START_SH" | sed -E 's/(.*)\/start_([a-zA-Z0-9_]+)\.sh$/\1_\2/')
+    else
+      APP_NAME=${APP_DIR}
+    fi
+    echo "APP_NAME=$APP_NAME"
     # Hardcode the connection to the DB in the start.sh
     if [ "$DB_URL" != "" ]; then
-      sed -i "s!##JDBC_URL##!$JDBC_URL!" $APP_DIR/start.sh 
-      sed -i "s!##DB_URL##!$DB_URL!" $APP_DIR/start.sh 
+      sed -i "s!##JDBC_URL##!$JDBC_URL!" $START_SH 
+      sed -i "s!##DB_URL##!$DB_URL!" $START_SH 
     fi  
-    sed -i "s!##TF_VAR_java_vm##!$TF_VAR_java_vm!" $APP_DIR/start.sh   
-    chmod +x $APP_DIR/start.sh
+    sed -i "s!##TF_VAR_java_vm##!$TF_VAR_java_vm!" $START_SH
+    chmod +x $START_SH
 
     # Create an "app.service" that starts when the machine starts.
-    cat > /tmp/$APP_DIR.service << EOT
+     cat > /tmp/$APP_NAME.service << EOT
 [Unit]
 Description=App
 After=network.target
 
 [Service]
 Type=simple
-ExecStart=/home/opc/$APP_DIR/start.sh
+ExecStart=/home/opc/$START_SH
 TimeoutStartSec=0
 User=opc
 
 [Install]
 WantedBy=default.target
 EOT
-
-    sudo cp /tmp/$APP_DIR.service /etc/systemd/system
-    sudo chmod 664 /etc/systemd/system/$APP_DIR.service
+    sudo cp /tmp/$APP_NAME.service /etc/systemd/system
+    sudo chmod 664 /etc/systemd/system/$APP_NAME.service
     sudo systemctl daemon-reload
-    sudo systemctl enable $APP_DIR.service
-    sudo systemctl restart $APP_DIR.service
-  fi
-done  
+    sudo systemctl enable $APP_NAME.service
+    sudo systemctl restart $APP_NAME.service
+    echo "sudo systemctl restart $APP_NAME" >> $APP_DIR/restart.sh 
+  done  
+done 
 
 # -- Helper --------------------------------------------------------------------
 cd $SCRIPT_DIR

--- a/option/compute/restart.sh
+++ b/option/compute/restart.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+sudo systemctl restart app
+

--- a/option/terraform/bastion.j2.tf
+++ b/option/terraform/bastion.j2.tf
@@ -89,7 +89,8 @@ resource "oci_core_instance" "starter_bastion" {
 
   lifecycle {
     ignore_changes = [
-      source_details[0].source_id
+      source_details[0].source_id,
+      shape
     ]
   }
 

--- a/option/terraform/compute.j2.tf
+++ b/option/terraform/compute.j2.tf
@@ -62,7 +62,8 @@ resource "oci_core_instance" "starter_compute" {
 
   lifecycle {
     ignore_changes = [
-      source_details[0].source_id
+      source_details[0].source_id,
+      shape
     ]
   }
   

--- a/option/terraform/opensearch.j2.tf
+++ b/option/terraform/opensearch.j2.tf
@@ -38,7 +38,7 @@ resource "oci_opensearch_opensearch_cluster" "starter_opensearch" {
   opendashboard_node_count           = 1
   opendashboard_node_host_memory_gb  = 16
   opendashboard_node_host_ocpu_count = 1
-  software_version                   = "2.11.0"
+  software_version                   = "2.19.1"
   subnet_compartment_id              = local.lz_network_cmp_ocid
   subnet_id                          = data.oci_core_subnet.starter_db_subnet.id
   vcn_compartment_id                 = local.lz_network_cmp_ocid


### PR DESCRIPTION
- guess_available_shape. scan all availability domain to use or  VM.Standard.E6.Flex/E5/E4 is available as default shape.
- TF_VAR_namespace also for compute and object storage
- next to greenlab of LiveLab - Lunalab auto-detection and find of compartment_ocid + TF_VAR_instance_shape
- config for TF_VAR_vault_ocid
- rename target directory after successful destroy to avoid people doing multiple build / delete and reusing previous settings.
- terraform precheck. Before to run the 1rst build. Run terraform plan and check if there are not existing bucket with the same name already to avoid error in the middle when several people install the same lab with the same prefix on the same tenancy
- starter.sh rebuild, start/stop, upgrade fixes
- compute
  -  allow now to have several start_xxx.sh in the app directory. For ex to have 1 python, 1 java and 1 node service in the same directory.
  - app contains now, init.sh, start_xxx.sh and restart.sh (new)